### PR TITLE
Otimiza impressão em massa no Painel de Saída (queries paralelas e opção de endereços)

### DIFF
--- a/backend/src/routes/painelSaida.ts
+++ b/backend/src/routes/painelSaida.ts
@@ -58,11 +58,18 @@ type LinhaEnderecoEstoque = {
   apto: string
 }
 
-const montarDadosImpressaoPorChave = async (chaves: string[]) => {
+const montarDadosImpressaoPorChave = async (
+  chaves: string[],
+  options?: {
+    incluirEnderecosEstoque?: boolean
+  },
+) => {
   const chavesLimpas = [...new Set(chaves.map((chave) => chave.trim()).filter(Boolean))]
   if (chavesLimpas.length === 0) return {}
 
-  const capasResult = await productPool.query<LinhaCapa>(
+  const incluirEnderecosEstoque = options?.incluirEnderecosEstoque !== false
+
+  const capasPromise = productPool.query<LinhaCapa>(
     `
       SELECT DISTINCT ON (TRIM(chave))
         data,
@@ -81,7 +88,7 @@ const montarDadosImpressaoPorChave = async (chaves: string[]) => {
     [chavesLimpas],
   )
 
-  const produtosResult = await productPool.query<LinhaProduto>(
+  const produtosPromise = productPool.query<LinhaProduto>(
     `
       SELECT
         TRIM(p.chave) AS chave,
@@ -102,7 +109,7 @@ const montarDadosImpressaoPorChave = async (chaves: string[]) => {
     [chavesLimpas],
   )
 
-  const enderecosMarcadosResult = await productPool.query<LinhaEnderecoMarcado>(
+  const enderecosMarcadosPromise = productPool.query<LinhaEnderecoMarcado>(
     `
       SELECT
         TRIM(em.chave) AS chave,
@@ -121,8 +128,9 @@ const montarDadosImpressaoPorChave = async (chaves: string[]) => {
     [chavesLimpas],
   )
 
-  const enderecosEstoqueResult = await productPool.query<LinhaEnderecoEstoque>(
-    `
+  const enderecosEstoquePromise = incluirEnderecosEstoque
+    ? productPool.query<LinhaEnderecoEstoque>(
+        `
       SELECT
         TRIM(p.chave) AS chave,
         el.codproduto,
@@ -142,8 +150,16 @@ const montarDadosImpressaoPorChave = async (chaves: string[]) => {
       JOIN wms_enderecos e ON el.codendereco = e.codendereco
       ORDER BY p.chave, el.codproduto, e.rua, e.predio, e.andar, e.apto
     `,
-    [chavesLimpas],
-  )
+        [chavesLimpas],
+      )
+    : Promise.resolve({ rows: [] } as { rows: LinhaEnderecoEstoque[] })
+
+  const [capasResult, produtosResult, enderecosMarcadosResult, enderecosEstoqueResult] = await Promise.all([
+    capasPromise,
+    produtosPromise,
+    enderecosMarcadosPromise,
+    enderecosEstoquePromise,
+  ])
 
   const produtosPorChave = new Map<string, LinhaProduto[]>()
   produtosResult.rows.forEach((produto) => {
@@ -331,7 +347,8 @@ router.get("/:chave/imprimir", async (req, res) => {
 router.post("/imprimir-lote", async (req, res) => {
   try {
     const chaves = Array.isArray(req.body?.chaves) ? req.body.chaves : []
-    const dadosPorChave = await montarDadosImpressaoPorChave(chaves)
+    const incluirEnderecosEstoque = req.body?.incluirEnderecosEstoque !== false
+    const dadosPorChave = await montarDadosImpressaoPorChave(chaves, { incluirEnderecosEstoque })
     res.json({ dadosPorChave })
   } catch (error) {
     logger.error("Erro ao buscar dados para impressão em lote:", error)

--- a/frontend/src/pages/PainelSaida.tsx
+++ b/frontend/src/pages/PainelSaida.tsx
@@ -777,7 +777,10 @@ const PainelSaida: React.FC = () => {
 
       const chavesOrdenadas = preNotasFiltradas.filter((pn) => selecionadasParaImpressao.has(pn.chave)).map((pn) => pn.chave)
 
-      const respostaLote = await api.post("/painel-saida/imprimir-lote", { chaves: chavesOrdenadas })
+      const respostaLote = await api.post("/painel-saida/imprimir-lote", {
+        chaves: chavesOrdenadas,
+        incluirEnderecosEstoque: config.modeloImpressao === 1,
+      })
       const dadosPorChave = respostaLote.data?.dadosPorChave || {}
 
       const blocos = chavesOrdenadas


### PR DESCRIPTION
### Motivation

- A montagem das pré-notas para impressão em massa estava lenta (≈60s) devido a consultas sequenciais e carga desnecessária de `enderecosEstoque` mesmo quando o modelo de impressão não usa endereços por produto.

### Description

- Modifiquei `montarDadosImpressaoPorChave` para aceitar um segundo parâmetro `options` com `incluirEnderecosEstoque` e para executar as consultas de `capas`, `produtos` e `enderecosMarcados` em paralelo usando `Promise.all`, reduzindo latência por I/O concorrente.
- Tornei a busca de `enderecosEstoque` opcional e só a executo quando `incluirEnderecosEstoque` for `true`, evitando custo de banco quando não necessário.
- Atualizei a rota `POST /painel-saida/imprimir-lote` para aceitar `incluirEnderecosEstoque` e repassar essa opção ao montador de dados.
- No frontend (`PainelSaida.tsx`) a chamada de impressão em massa agora envia `incluirEnderecosEstoque: config.modeloImpressao === 1` para evitar trazer endereços quando o modelo é simplificado.

### Testing

- Executei `npx tsc -p backend/tsconfig.json --noEmit` para checagem de tipos do backend e o comando completou sem erros.
- Tentei rodar `npm run build` do frontend para validação da build, mas o processo ficou excessivamente longo no ambiente e foi interrompido antes de terminar; alterações no frontend são localizadas em `frontend/src/pages/PainelSaida.tsx` e devem ser validadas em CI ou ambiente de desenvolvimento ao reconstruir o front-end.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b84594de088324ac622e6b9002c25f)