### PR TITLE
Ordena painel de saída por chave decrescente

### DIFF
--- a/backend/src/routes/painelSaida.ts
+++ b/backend/src/routes/painelSaida.ts
@@ -272,7 +272,7 @@ router.get("/", async (req, res) => {
       FROM vs_wms_fpainel_saida p
       LEFT JOIN wms_separacoes s
         ON s.chave::text = p.chave::text
-      ORDER BY p.data DESC
+      ORDER BY TRIM(p.chave) DESC, p.data DESC
     `
     const result = await productPool.query(query)
     res.json(result.rows)


### PR DESCRIPTION
### Motivation
- Garantir que as pré-notas mais recentes apareçam primeiro no `GET /painel-saida` ordenando pela coluna `chave` em ordem decrescente.

### Description
- Atualizei a query em `backend/src/routes/painelSaida.ts` para usar `ORDER BY TRIM(p.chave) DESC, p.data DESC` no lugar de `ORDER BY p.data DESC`, adicionando `TRIM` para evitar diferenças por espaços.

### Testing
- Executei `cd /workspace/wms/backend && npx tsc --noEmit` e não houve erros de compilação.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8526f1f2c83248d7baa39bd426b90)