### PR TITLE
Fix /painel-saida 500 by using DISTINCT ON and trimming chave

### DIFF
--- a/backend/src/routes/painelSaida.ts
+++ b/backend/src/routes/painelSaida.ts
@@ -254,7 +254,7 @@ const montarDadosImpressaoPorChave = async (
 router.get("/", async (req, res) => {
   try {
     const query = `
-      SELECT DISTINCT
+      SELECT DISTINCT ON (TRIM(p.chave))
         p.data,
         p.codloja,
         p.op,
@@ -266,7 +266,7 @@ router.get("/", async (req, res) => {
         p.separacao,
         p.coddestinario,
         p.destinario,
-        p.chave,
+        TRIM(p.chave) AS chave,
         s.status AS separacao_status,
         s.usuario_atribuido AS separador
       FROM vs_wms_fpainel_saida p


### PR DESCRIPTION
### Motivation
- Corrigir erro 500 na rota `GET /painel-saida` causado por incompatibilidade entre `DISTINCT` e a cláusula `ORDER BY` ao agrupar por `chave`, e garantir que o campo `chave` retornado não contenha espaços extras.

### Description
- Altere a query de listagem para usar `SELECT DISTINCT ON (TRIM(p.chave))` para garantir uma linha por `chave` ordenada corretamente.
- Normalizei o campo retornado para `TRIM(p.chave) AS chave` para remover espaços em branco e padronizar o payload enviado ao frontend.
- Mantive a ordenação por `TRIM(p.chave) DESC, p.data DESC` para preservar a escolha da linha mais recente por chave.

### Testing
- Executei verificação de tipos TypeScript com `cd backend && npx tsc --noEmit`, que passou com sucesso.
- Tentei executar `cd backend && npm run build`, que falhou porque o script `build` não existe no `package.json` (informativo, não relacionado ao patch).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b854c9991c8324bd064585a284cb8f)