### PR TITLE
Adiciona Painel Entrega e botao Separar Tudo

### DIFF
--- a/backend/scripts/criar_painel_entrega.sql
+++ b/backend/scripts/criar_painel_entrega.sql
@@ -1,0 +1,42 @@
+-- Script: Painel Entrega
+-- Executar como DBA no banco do WMS
+
+-- 1. Tabela de entregas
+CREATE TABLE IF NOT EXISTS wms_entregas (
+  id            serial PRIMARY KEY,
+  chave         varchar(10) NOT NULL UNIQUE,
+  codloja       integer NOT NULL,
+  np            varchar(20) NOT NULL,
+  destinario    varchar(100) NOT NULL,
+  endereco      varchar(200),
+  cidade_uf     varchar(100),
+  data_criacao  timestamp DEFAULT NOW(),
+  data_nf       timestamp,
+  data_saiu     timestamp,
+  data_entregue timestamp,
+  status        varchar(20) NOT NULL DEFAULT 'AguardandoNF'
+);
+
+-- 2. Registrar módulo (ajuste o campo "ordem" se necessário)
+INSERT INTO wms_modulos (nome, rota, icone, ordem, ativo)
+VALUES (
+  'Painel Entrega',
+  'painelentrega',
+  'local_shipping',
+  (SELECT COALESCE(MAX(ordem), 0) + 1 FROM wms_modulos),
+  true
+);
+
+-- 3. Conceder permissões a todos os níveis de acesso ativos
+INSERT INTO wms_permissoes_nivel (codigo_nivel, id_modulo, visualizar, incluir, editar, excluir)
+SELECT
+  na.codigo,
+  m.id,
+  true,   -- visualizar
+  false,  -- incluir
+  true,   -- editar (necessário para atualizar status de entrega)
+  false   -- excluir
+FROM wms_niveis_acesso na
+CROSS JOIN wms_modulos m
+WHERE m.rota = 'painelentrega'
+  AND na.ativo = true;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -13,6 +13,7 @@ import dashboardRoutes from "./routes/dashboard"
 import impressoraZebraRoutes from "./routes/impressoraZebra"
 import separacaoRoutes from "./routes/separacao"
 import painelSeparacaoPublicoRoutes from "./routes/painelSeparacaoPublico"
+import painelEntregaRoutes from "./routes/painelEntrega"
 import { logger } from "./utils/logger"
 
 const app = express()
@@ -60,6 +61,7 @@ app.use("/controle-acesso", controleAcessoRoutes)
 app.use("/dashboard", dashboardRoutes)
 app.use("/impressora/zebra", impressoraZebraRoutes)
 app.use("/separacao", separacaoRoutes)
+app.use("/painel-entrega", painelEntregaRoutes)
 
 // Iniciar o servidor
 app.listen(PORT, () => {

--- a/backend/src/routes/painelEntrega.ts
+++ b/backend/src/routes/painelEntrega.ts
@@ -1,0 +1,93 @@
+import express from "express"
+import { productPool } from "../database"
+import { logger } from "../utils/logger"
+
+const router = express.Router()
+
+// Transições de status permitidas por ação do usuário
+const TRANSICOES_VALIDAS: Record<string, string> = {
+  SaiuEntrega: "NFEmitida",
+  Entregue: "SaiuEntrega",
+}
+
+const CAMPO_DATA: Record<string, string> = {
+  SaiuEntrega: "data_saiu",
+  Entregue: "data_entregue",
+}
+
+router.get("/", async (_req, res) => {
+  try {
+    // Detecta NF emitida: chaves que saíram da view do painel de saída
+    await productPool.query(
+      `UPDATE wms_entregas
+       SET status = 'NFEmitida', data_nf = NOW()
+       WHERE status = 'AguardandoNF'
+         AND NOT EXISTS (
+           SELECT 1
+           FROM vs_wms_fpainel_saida ps
+           WHERE ps.chave::text = wms_entregas.chave::text
+         )`,
+    )
+
+    const result = await productPool.query(
+      `SELECT
+         id, chave, codloja, np, destinario, endereco, cidade_uf,
+         status, data_criacao, data_nf, data_saiu, data_entregue
+       FROM wms_entregas
+       WHERE status <> 'Entregue'
+          OR data_entregue >= NOW() - INTERVAL '3 days'
+       ORDER BY data_criacao DESC`,
+    )
+
+    res.json(result.rows)
+  } catch (error) {
+    logger.error("Erro ao buscar painel de entregas:", error)
+    res.status(500).json({ erro: "Erro ao buscar entregas" })
+  }
+})
+
+router.post("/status", async (req, res) => {
+  const { chave, status } = req.body
+
+  if (!chave || !status) {
+    return res.status(400).json({ erro: "chave e status são obrigatórios" })
+  }
+
+  const statusPrerequisito = TRANSICOES_VALIDAS[status]
+  if (!statusPrerequisito) {
+    return res.status(400).json({ erro: "Status inválido. Use SaiuEntrega ou Entregue" })
+  }
+
+  try {
+    const atual = await productPool.query(
+      `SELECT status FROM wms_entregas WHERE chave = $1`,
+      [chave],
+    )
+
+    if (atual.rows.length === 0) {
+      return res.status(404).json({ erro: "Entrega não encontrada" })
+    }
+
+    if (atual.rows[0].status !== statusPrerequisito) {
+      return res.status(409).json({
+        erro: `Status atual deve ser '${statusPrerequisito}' para avançar para '${status}'`,
+      })
+    }
+
+    const campoData = CAMPO_DATA[status]
+    const result = await productPool.query(
+      `UPDATE wms_entregas
+       SET status = $2, ${campoData} = NOW()
+       WHERE chave = $1
+       RETURNING *`,
+      [chave, status],
+    )
+
+    res.json({ mensagem: "Status atualizado", entrega: result.rows[0] })
+  } catch (error) {
+    logger.error("Erro ao atualizar status da entrega:", error)
+    res.status(500).json({ erro: "Erro ao atualizar status" })
+  }
+})
+
+export default router

--- a/backend/src/routes/separacao.ts
+++ b/backend/src/routes/separacao.ts
@@ -204,6 +204,47 @@ router.post("/item", async (req, res) => {
   }
 })
 
+router.post("/separar-tudo", async (req, res) => {
+  const { chave, codloja, np } = req.body
+  const chaveNormalizada = normalizarTextoOpcional(chave)
+  const codlojaNormalizada = normalizarInteiroOpcional(codloja)
+  const npNormalizado = normalizarTextoOpcional(np)
+
+  if (!chaveNormalizada && (codlojaNormalizada == null || !npNormalizado)) {
+    return res.status(400).json({ erro: "chave ou codloja e np são obrigatórios" })
+  }
+
+  try {
+    const separacao = await productPool.query(
+      `SELECT status FROM wms_separacoes
+       WHERE chave::text = $1::text OR (codloja = $2 AND np::text = $3::text)
+       LIMIT 1`,
+      [chaveNormalizada, codlojaNormalizada, npNormalizado],
+    )
+
+    if (separacao.rows[0]?.status === "F") {
+      return res.status(409).json({ erro: "Separação finalizada não pode ser alterada" })
+    }
+
+    const result = await productPool.query(
+      `UPDATE wms_separacao_itens
+       SET qtde_separada = qtde_total
+       WHERE chave::text = $1::text OR (codloja = $2 AND np::text = $3::text)
+       RETURNING *`,
+      [chaveNormalizada, codlojaNormalizada, npNormalizado],
+    )
+
+    if (result.rows.length === 0) {
+      return res.status(404).json({ erro: "Itens não encontrados" })
+    }
+
+    res.json({ mensagem: "Todos os itens separados", itens: result.rowCount })
+  } catch (error) {
+    logger.error("Erro ao separar todos os itens:", error)
+    res.status(500).json({ erro: "Erro ao separar todos os itens" })
+  }
+})
+
 router.post("/finalizar", async (req, res) => {
   const { chave, codloja, np } = req.body
   const chaveNormalizada = normalizarTextoOpcional(chave)
@@ -240,7 +281,36 @@ router.post("/finalizar", async (req, res) => {
       return res.status(404).json({ erro: "Separação não encontrada" })
     }
 
-    res.json({ mensagem: "Separação finalizada", separacao: result.rows[0] })
+    const separacao = result.rows[0]
+
+    if (separacao.tipoentrega === "LojaEntrega") {
+      try {
+        const dadosView = await productPool.query(
+          `SELECT MAX(endereco) AS endereco, MAX(cidade_uf) AS cidade_uf
+           FROM vs_wms_fpainel_saida
+           WHERE chave = $1`,
+          [separacao.chave],
+        )
+
+        await productPool.query(
+          `INSERT INTO wms_entregas (chave, codloja, np, destinario, endereco, cidade_uf)
+           VALUES ($1, $2, $3, $4, $5, $6)
+           ON CONFLICT (chave) DO NOTHING`,
+          [
+            separacao.chave,
+            separacao.codloja,
+            separacao.np,
+            separacao.destinario,
+            dadosView.rows[0]?.endereco ?? null,
+            dadosView.rows[0]?.cidade_uf ?? null,
+          ],
+        )
+      } catch (entregaError) {
+        logger.error("Erro ao registrar entrega após finalizar separação:", entregaError)
+      }
+    }
+
+    res.json({ mensagem: "Separação finalizada", separacao })
   } catch (error) {
     logger.error("Erro ao finalizar separação:", error)
     res.status(500).json({ erro: "Erro ao finalizar separação" })

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import PainelSaida from "./pages/PainelSaida"
 import PainelSeparacao from "./pages/PainelSeparacao"
 import ImprimirEtiquetasEnderecos from "./pages/ImprimirEtiquetasEnderecos"
 import PainelSeparacaoTV from "./pages/PainelSeparacaoTV"
+import PainelEntrega from "./pages/PainelEntrega"
 
 const theme = createTheme(
   {
@@ -133,6 +134,14 @@ function App() {
               element={
                 <ProtectedRoute requiredPermission={{ rota: "painelseparacao", tipo: "visualizar" }}>
                   <PainelSeparacao />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/painelentrega"
+              element={
+                <ProtectedRoute requiredPermission={{ rota: "painelentrega", tipo: "visualizar" }}>
+                  <PainelEntrega />
                 </ProtectedRoute>
               }
             />

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -56,6 +56,7 @@ const routeIconMap: Record<string, React.ReactElement> = {
     painelentrada: <ShoppingCartIcon />,
     painelsaida: <LocalShippingIcon />,
     painelseparacao: <AssignmentIcon />,
+    painelentrega: <LocalShippingIcon />,
     relatorios: <BarChartIcon />,
     estoque: <StorageIcon />,
     impressaoconferencia: <PrintIcon />,

--- a/frontend/src/pages/PainelEntrega.tsx
+++ b/frontend/src/pages/PainelEntrega.tsx
@@ -1,0 +1,243 @@
+"use client"
+
+import React, { useCallback, useEffect, useMemo, useState } from "react"
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Container,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Paper,
+  Select,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+  alpha,
+} from "@mui/material"
+import { Layout } from "../components/Layout"
+import { useAuth } from "../contexts/AuthContext"
+import api from "../services/api"
+
+interface Entrega {
+  id: number
+  chave: string
+  codloja: number
+  np: string
+  destinario: string
+  endereco: string | null
+  cidade_uf: string | null
+  status: "AguardandoNF" | "NFEmitida" | "SaiuEntrega" | "Entregue"
+  data_criacao: string
+  data_nf: string | null
+  data_saiu: string | null
+  data_entregue: string | null
+}
+
+const STATUS_CONFIG: Record<Entrega["status"], { label: string; color: "warning" | "info" | "secondary" | "success" }> = {
+  AguardandoNF: { label: "Aguardando NF", color: "warning" },
+  NFEmitida: { label: "NF Emitida", color: "info" },
+  SaiuEntrega: { label: "Saiu para Entrega", color: "secondary" },
+  Entregue: { label: "Entregue", color: "success" },
+}
+
+const formatarData = (data: string | null): string => {
+  if (!data) return "-"
+  return new Date(data).toLocaleString("pt-BR")
+}
+
+const PainelEntrega: React.FC = () => {
+  const { empresa, corTopo } = useAuth()
+  const nomeEmpresa = empresa?.nome || "Sistema WMS"
+  const [carregando, setCarregando] = useState(true)
+  const [entregas, setEntregas] = useState<Entrega[]>([])
+  const [filtro, setFiltro] = useState("")
+  const [filtroStatus, setFiltroStatus] = useState("")
+  const [atualizando, setAtualizando] = useState<Record<string, boolean>>({})
+
+  const buscarEntregas = useCallback(async () => {
+    try {
+      const response = await api.get("/painel-entrega")
+      setEntregas(response.data)
+    } finally {
+      setCarregando(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    buscarEntregas()
+    const interval = setInterval(buscarEntregas, 30000)
+    return () => clearInterval(interval)
+  }, [buscarEntregas])
+
+  const entregasFiltradas = useMemo(() => {
+    return entregas.filter((item) => {
+      const busca = filtro.toLowerCase()
+      const atendeBusca =
+        item.np?.toLowerCase().includes(busca) ||
+        String(item.codloja).includes(busca) ||
+        item.destinario?.toLowerCase().includes(busca) ||
+        (item.endereco ?? "").toLowerCase().includes(busca)
+
+      const atendeStatus = !filtroStatus || item.status === filtroStatus
+      return atendeBusca && atendeStatus
+    })
+  }, [entregas, filtro, filtroStatus])
+
+  const atualizarStatus = async (chave: string, novoStatus: "SaiuEntrega" | "Entregue") => {
+    setAtualizando((prev) => ({ ...prev, [chave]: true }))
+    try {
+      await api.post("/painel-entrega/status", { chave, status: novoStatus })
+      await buscarEntregas()
+    } catch (error) {
+      console.error("Erro ao atualizar status da entrega:", error)
+    } finally {
+      setAtualizando((prev) => ({ ...prev, [chave]: false }))
+    }
+  }
+
+  const acaoDisponivel = (item: Entrega) => {
+    if (atualizando[item.chave]) {
+      return <CircularProgress size={20} />
+    }
+
+    if (item.status === "NFEmitida") {
+      return (
+        <Button
+          size="small"
+          variant="contained"
+          color="warning"
+          onClick={() => {
+            void atualizarStatus(item.chave, "SaiuEntrega")
+          }}
+        >
+          Saiu para Entrega
+        </Button>
+      )
+    }
+
+    if (item.status === "SaiuEntrega") {
+      return (
+        <Button
+          size="small"
+          variant="contained"
+          color="success"
+          onClick={() => {
+            void atualizarStatus(item.chave, "Entregue")
+          }}
+        >
+          Marcar Entregue
+        </Button>
+      )
+    }
+
+    return null
+  }
+
+  return (
+    <Layout corTopo={corTopo} nomeEmpresa={nomeEmpresa}>
+      <Container maxWidth={false} sx={{ py: 3 }}>
+        <Paper sx={{ p: 3, mb: 2, borderRadius: 2, boxShadow: "0 2px 8px rgba(0, 0, 0, 0.08)" }}>
+          <Typography variant="h5" sx={{ mb: 2, color: corTopo, fontWeight: 700 }}>
+            Painel de Entregas
+          </Typography>
+          <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
+            <TextField
+              size="small"
+              label="Buscar por loja, nota ou destinatário"
+              value={filtro}
+              onChange={(e) => setFiltro(e.target.value)}
+              sx={{ flex: 1, minWidth: 250 }}
+            />
+            <FormControl size="small" sx={{ minWidth: 220 }}>
+              <InputLabel id="filtro-status-entrega-label">Filtrar por status</InputLabel>
+              <Select
+                labelId="filtro-status-entrega-label"
+                label="Filtrar por status"
+                value={filtroStatus}
+                onChange={(e) => setFiltroStatus(e.target.value)}
+              >
+                <MenuItem value="">Todos</MenuItem>
+                {Object.entries(STATUS_CONFIG).map(([key, cfg]) => (
+                  <MenuItem key={key} value={key}>
+                    {cfg.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Box>
+        </Paper>
+
+        <TableContainer component={Paper} sx={{ borderRadius: 2, border: "1px solid", borderColor: "divider" }}>
+          <Table size="small">
+            <TableHead>
+              <TableRow sx={{ backgroundColor: "#f3f4f6" }}>
+                <TableCell sx={{ fontWeight: 600 }}>Loja</TableCell>
+                <TableCell sx={{ fontWeight: 600 }}>Nota</TableCell>
+                <TableCell sx={{ fontWeight: 600 }}>Destinatário</TableCell>
+                <TableCell sx={{ fontWeight: 600 }}>Endereço</TableCell>
+                <TableCell sx={{ fontWeight: 600 }}>Cidade/UF</TableCell>
+                <TableCell sx={{ fontWeight: 600 }}>Status</TableCell>
+                <TableCell sx={{ fontWeight: 600 }}>NF Emitida</TableCell>
+                <TableCell sx={{ fontWeight: 600 }}>Saiu p/ Entrega</TableCell>
+                <TableCell sx={{ fontWeight: 600 }}>Entregue</TableCell>
+                <TableCell sx={{ fontWeight: 600 }} align="center">
+                  Ação
+                </TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {carregando ? (
+                <TableRow>
+                  <TableCell colSpan={10} align="center" sx={{ py: 4 }}>
+                    <CircularProgress />
+                  </TableCell>
+                </TableRow>
+              ) : entregasFiltradas.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={10} align="center">
+                    <Alert severity="info">Nenhuma entrega encontrada.</Alert>
+                  </TableCell>
+                </TableRow>
+              ) : (
+                entregasFiltradas.map((item) => (
+                  <TableRow
+                    key={item.chave}
+                    sx={{ "&:nth-of-type(even)": { backgroundColor: alpha("#f3f4f6", 0.3) } }}
+                  >
+                    <TableCell>{item.codloja}</TableCell>
+                    <TableCell>{item.np}</TableCell>
+                    <TableCell>{item.destinario}</TableCell>
+                    <TableCell>{item.endereco || "-"}</TableCell>
+                    <TableCell>{item.cidade_uf || "-"}</TableCell>
+                    <TableCell>
+                      <Chip
+                        size="small"
+                        color={STATUS_CONFIG[item.status]?.color ?? "default"}
+                        label={STATUS_CONFIG[item.status]?.label ?? item.status}
+                      />
+                    </TableCell>
+                    <TableCell>{formatarData(item.data_nf)}</TableCell>
+                    <TableCell>{formatarData(item.data_saiu)}</TableCell>
+                    <TableCell>{formatarData(item.data_entregue)}</TableCell>
+                    <TableCell align="center">{acaoDisponivel(item)}</TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Container>
+    </Layout>
+  )
+}
+
+export default PainelEntrega

--- a/frontend/src/pages/PainelSeparacao.tsx
+++ b/frontend/src/pages/PainelSeparacao.tsx
@@ -88,6 +88,7 @@ const PainelSeparacao: React.FC = () => {
   const [detalhesExpandidos, setDetalhesExpandidos] = useState<Record<string, boolean>>({})
   const [itensPorChave, setItensPorChave] = useState<Record<string, ItemSeparacao[]>>({})
   const [carregandoItens, setCarregandoItens] = useState<Record<string, boolean>>({})
+  const [separandoTudo, setSeparandoTudo] = useState<Record<string, boolean>>({})
 
   const normalizarQuantidade = (valor: number, maximo: number) => {
     if (!Number.isFinite(valor)) return 0
@@ -192,6 +193,18 @@ const PainelSeparacao: React.FC = () => {
     setDetalhesExpandidos((prev) => ({ ...prev, [chave]: !estaAberto }))
     if (!estaAberto && !itensPorChave[chave]) {
       await buscarItens(chave)
+    }
+  }
+
+  const separarTudo = async (chave: string) => {
+    setSeparandoTudo((prev) => ({ ...prev, [chave]: true }))
+    try {
+      await api.post("/separacao/separar-tudo", { chave })
+      await Promise.all([buscarItens(chave), buscarSeparacoes()])
+    } catch (error) {
+      console.error("Erro ao separar todos os itens:", error)
+    } finally {
+      setSeparandoTudo((prev) => ({ ...prev, [chave]: false }))
     }
   }
 
@@ -367,9 +380,24 @@ const PainelSeparacao: React.FC = () => {
                       <TableCell colSpan={11} sx={{ p: 0, borderBottom: 0 }}>
                         <Collapse in={Boolean(detalhesExpandidos[item.chave])} timeout="auto" unmountOnExit>
                           <Box sx={{ p: 2, backgroundColor: "#f9fafb" }}>
-                            <Typography variant="subtitle2" sx={{ mb: 1, fontWeight: 600 }}>
-                              Conferência por produto
-                            </Typography>
+                            <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 1 }}>
+                              <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+                                Conferência por produto
+                              </Typography>
+                              {item.status !== "F" && (
+                                <Button
+                                  size="small"
+                                  variant="outlined"
+                                  color="primary"
+                                  disabled={Boolean(separandoTudo[item.chave])}
+                                  onClick={() => {
+                                    void separarTudo(item.chave)
+                                  }}
+                                >
+                                  {separandoTudo[item.chave] ? "Separando..." : "Separar Tudo"}
+                                </Button>
+                              )}
+                            </Box>
                             {carregandoItens[item.chave] ? (
                               <Box display="flex" justifyContent="center" py={2}>
                                 <CircularProgress size={22} />


### PR DESCRIPTION
## O que mudou

### Botao Separar Tudo - Painel Separacao
Novo botao no painel de conferencia expandido. Seta qtde_separada = qtde_total para todos os itens de uma vez via POST /separacao/separar-tudo. Disponivel sempre que a separacao estiver em andamento.

### Novo modulo: Painel Entrega
Fluxo para notas LojaEntrega:
- AguardandoNF (ao finalizar separacao)
- NFEmitida (automatico, polling 30s, detectado pela ausencia da chave em vs_wms_fpainel_saida)
- Saiu para Entrega (usuario)
- Entregue (usuario)

Entregas somem do painel apos 3 dias de Entregue. Notas ClienteRetira sem alteracao.

## Pre-requisito
Executar backend/scripts/criar_painel_entrega.sql no banco antes de subir.

Generated with Claude Code