### PR TITLE
Corrige ON CONFLICT incompatível e ordem do Painel Entrega no menu

### DIFF
--- a/backend/scripts/corrigir_ordem_painel_entrega.sql
+++ b/backend/scripts/corrigir_ordem_painel_entrega.sql
@@ -1,0 +1,12 @@
+-- Corrige a posição do módulo Painel Entrega no menu:
+-- coloca logo após o Painel Separação.
+-- Executar apenas se o módulo já foi criado pelo script criar_painel_entrega.sql.
+
+UPDATE wms_modulos
+SET ordem = ordem + 1
+WHERE ordem > (SELECT ordem FROM wms_modulos WHERE rota = 'painelseparacao')
+  AND rota <> 'painelentrega';
+
+UPDATE wms_modulos
+SET ordem = (SELECT ordem FROM wms_modulos WHERE rota = 'painelseparacao') + 1
+WHERE rota = 'painelentrega';

--- a/backend/scripts/criar_painel_entrega.sql
+++ b/backend/scripts/criar_painel_entrega.sql
@@ -3,8 +3,8 @@
 
 -- 1. Tabela de entregas
 CREATE TABLE IF NOT EXISTS wms_entregas (
-  id            serial PRIMARY KEY,
-  chave         varchar(10) NOT NULL UNIQUE,
+  id            serial,
+  chave         varchar(10) NOT NULL,
   codloja       integer NOT NULL,
   np            varchar(20) NOT NULL,
   destinario    varchar(100) NOT NULL,
@@ -14,18 +14,31 @@ CREATE TABLE IF NOT EXISTS wms_entregas (
   data_nf       timestamp,
   data_saiu     timestamp,
   data_entregue timestamp,
-  status        varchar(20) NOT NULL DEFAULT 'AguardandoNF'
+  status        varchar(20) NOT NULL DEFAULT 'AguardandoNF',
+  CONSTRAINT wms_entregas_pkey PRIMARY KEY (id),
+  CONSTRAINT wms_entregas_chave_unique UNIQUE (chave)
 );
 
--- 2. Registrar módulo (ajuste o campo "ordem" se necessário)
+-- 2. Registrar módulo logo após o Painel Separação
 INSERT INTO wms_modulos (nome, rota, icone, ordem, ativo)
-VALUES (
+SELECT
   'Painel Entrega',
   'painelentrega',
   'local_shipping',
-  (SELECT COALESCE(MAX(ordem), 0) + 1 FROM wms_modulos),
+  COALESCE((SELECT ordem FROM wms_modulos WHERE rota = 'painelseparacao'), 0) + 1,
   true
-);
+WHERE NOT EXISTS (SELECT 1 FROM wms_modulos WHERE rota = 'painelentrega');
+
+-- Abre espaço para o novo módulo ficar logo após o Painel Separação
+UPDATE wms_modulos
+SET ordem = ordem + 1
+WHERE ordem > COALESCE((SELECT ordem FROM wms_modulos WHERE rota = 'painelseparacao'), 0)
+  AND rota <> 'painelentrega';
+
+-- Garante que a ordem do Painel Entrega seja logo após Painel Separação
+UPDATE wms_modulos
+SET ordem = COALESCE((SELECT ordem FROM wms_modulos WHERE rota = 'painelseparacao'), 0) + 1
+WHERE rota = 'painelentrega';
 
 -- 3. Conceder permissões a todos os níveis de acesso ativos
 INSERT INTO wms_permissoes_nivel (codigo_nivel, id_modulo, visualizar, incluir, editar, excluir)
@@ -39,4 +52,8 @@ SELECT
 FROM wms_niveis_acesso na
 CROSS JOIN wms_modulos m
 WHERE m.rota = 'painelentrega'
-  AND na.ativo = true;
+  AND na.ativo = true
+  AND NOT EXISTS (
+    SELECT 1 FROM wms_permissoes_nivel p
+    WHERE p.codigo_nivel = na.codigo AND p.id_modulo = m.id
+  );

--- a/backend/src/routes/separacao.ts
+++ b/backend/src/routes/separacao.ts
@@ -294,8 +294,8 @@ router.post("/finalizar", async (req, res) => {
 
         await productPool.query(
           `INSERT INTO wms_entregas (chave, codloja, np, destinario, endereco, cidade_uf)
-           VALUES ($1, $2, $3, $4, $5, $6)
-           ON CONFLICT (chave) DO NOTHING`,
+           SELECT $1, $2, $3, $4, $5, $6
+           WHERE NOT EXISTS (SELECT 1 FROM wms_entregas WHERE chave = $1)`,
           [
             separacao.chave,
             separacao.codloja,


### PR DESCRIPTION
## O que mudou

### Correção: INSERT em wms_entregas falhava com erro 42601
O `ON CONFLICT (chave) DO NOTHING` requer PostgreSQL >= 9.5. Substituído por `WHERE NOT EXISTS` que é compatível com todas as versões.

### Correção: ordem do módulo Painel Entrega no menu
- Script `criar_painel_entrega.sql` atualizado: módulo já é inserido com ordem logo após Painel Separação
- Novo script `corrigir_ordem_painel_entrega.sql` para quem já rodou o script anterior

## Para quem já rodou o script anterior

Executar no banco:

```sql
-- corrigir_ordem_painel_entrega.sql
UPDATE wms_modulos
SET ordem = ordem + 1
WHERE ordem > (SELECT ordem FROM wms_modulos WHERE rota = 'painelseparacao')
  AND rota <> 'painelentrega';

UPDATE wms_modulos
SET ordem = (SELECT ordem FROM wms_modulos WHERE rota = 'painelseparacao') + 1
WHERE rota = 'painelentrega';
```

Generated with Claude Code