### PR TITLE
Corrige tipo ambíguo INSERT, filtro 3 dias separação e ordem menu

### DIFF
--- a/backend/scripts/corrigir_ordem_painel_entrega.sql
+++ b/backend/scripts/corrigir_ordem_painel_entrega.sql
@@ -1,12 +1,23 @@
--- Corrige a posição do módulo Painel Entrega no menu:
--- coloca logo após o Painel Separação.
--- Executar apenas se o módulo já foi criado pelo script criar_painel_entrega.sql.
+-- Reposiciona o módulo Painel Entrega logo após o Painel Separação no menu.
+-- Executar no banco do WMS.
 
+-- Passo 1: abre uma posição logo após o Painel Separação
 UPDATE wms_modulos
 SET ordem = ordem + 1
-WHERE ordem > (SELECT ordem FROM wms_modulos WHERE rota = 'painelseparacao')
-  AND rota <> 'painelentrega';
+WHERE ordem > (
+    SELECT ordem FROM wms_modulos
+    WHERE nome ILIKE '%separa%'
+    ORDER BY ordem DESC
+    LIMIT 1
+)
+AND nome NOT ILIKE '%entrega%';
 
+-- Passo 2: posiciona o Painel Entrega na posição aberta
 UPDATE wms_modulos
-SET ordem = (SELECT ordem FROM wms_modulos WHERE rota = 'painelseparacao') + 1
-WHERE rota = 'painelentrega';
+SET ordem = (
+    SELECT ordem FROM wms_modulos
+    WHERE nome ILIKE '%separa%'
+    ORDER BY ordem DESC
+    LIMIT 1
+) + 1
+WHERE nome ILIKE '%entrega%';

--- a/backend/src/routes/separacao.ts
+++ b/backend/src/routes/separacao.ts
@@ -294,8 +294,8 @@ router.post("/finalizar", async (req, res) => {
 
         await productPool.query(
           `INSERT INTO wms_entregas (chave, codloja, np, destinario, endereco, cidade_uf)
-           SELECT $1, $2, $3, $4, $5, $6
-           WHERE NOT EXISTS (SELECT 1 FROM wms_entregas WHERE chave = $1)`,
+           SELECT $1::varchar(10), $2::integer, $3::varchar(20), $4::varchar(100), $5::varchar(200), $6::varchar(100)
+           WHERE NOT EXISTS (SELECT 1 FROM wms_entregas WHERE chave::text = $1::text)`,
           [
             separacao.chave,
             separacao.codloja,
@@ -364,6 +364,7 @@ router.get("/", async (req, res) => {
          FROM wms_separacoes s
          WHERE ($1::varchar(50) IS NULL OR s.usuario_atribuido::text = $1::text)
            AND ($2::varchar(15) IS NULL OR s.tipoentrega::text = $2::text)
+           AND (s.status <> 'F' OR s.data_fim >= NOW() - INTERVAL '3 days')
        ),
        itens_por_chave AS (
          SELECT


### PR DESCRIPTION
## Correções

### 1. Erro 42P08 — ambiguidade de tipo no INSERT em wms_entregas
O PostgreSQL não conseguia inferir o tipo do parâmetro `$1` usado tanto no SELECT quanto no WHERE. Adicionados casts explícitos em todos os parâmetros do INSERT SELECT.

### 2. Painel Separação — separações finalizadas sumindo após 3 dias
Adicionado filtro `(status <> 'F' OR data_fim >= NOW() - INTERVAL '3 days')` na query de listagem. Separações em andamento continuam aparecendo normalmente; as finalizadas somem depois de 3 dias.

### 3. Script de correção do menu
Script `corrigir_ordem_painel_entrega.sql` reescrito usando `ILIKE` para localizar os módulos pelo nome em vez do valor exato da rota — mais robusto contra variações de cadastro.

## Para executar no banco

```sql
-- backend/scripts/corrigir_ordem_painel_entrega.sql
UPDATE wms_modulos
SET ordem = ordem + 1
WHERE ordem > (
    SELECT ordem FROM wms_modulos
    WHERE nome ILIKE '%separa%'
    ORDER BY ordem DESC LIMIT 1
)
AND nome NOT ILIKE '%entrega%';

UPDATE wms_modulos
SET ordem = (
    SELECT ordem FROM wms_modulos
    WHERE nome ILIKE '%separa%'
    ORDER BY ordem DESC LIMIT 1
) + 1
WHERE nome ILIKE '%entrega%';
```

Generated with Claude Code