### PR TITLE
Separa leitura de detecção de NF — elimina bloqueio de tabela no GET

### DIFF
--- a/backend/scripts/criar_indices_performance.sql
+++ b/backend/scripts/criar_indices_performance.sql
@@ -1,36 +1,30 @@
 -- Índices de performance para Painel Separação e Painel Entrega
--- Executar no banco do WMS (operação segura — CREATE INDEX IF NOT EXISTS)
+-- Executar no banco do WMS FORA de uma transação (psql direto)
+-- CONCURRENTLY não bloqueia a tabela durante a criação
 
 -- ─── wms_separacoes ────────────────────────────────────────────────────────
 
--- Filtro principal: exclui finalizadas antigas (status + data_fim)
-CREATE INDEX IF NOT EXISTS idx_separacoes_status_data_fim
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_separacoes_status_data_fim
   ON wms_separacoes (status, data_fim);
 
--- Filtro por separador
-CREATE INDEX IF NOT EXISTS idx_separacoes_usuario
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_separacoes_usuario
   ON wms_separacoes (usuario_atribuido);
 
--- Filtro por tipo de entrega
-CREATE INDEX IF NOT EXISTS idx_separacoes_tipoentrega
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_separacoes_tipoentrega
   ON wms_separacoes (tipoentrega);
 
--- JOIN com wms_separacao_itens e vs_wms_fpainel_saida
-CREATE INDEX IF NOT EXISTS idx_separacoes_chave
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_separacoes_chave
   ON wms_separacoes (chave);
 
 -- ─── wms_separacao_itens ───────────────────────────────────────────────────
 
--- JOIN e agregação por chave (GROUP BY / SUM)
-CREATE INDEX IF NOT EXISTS idx_separacao_itens_chave
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_separacao_itens_chave
   ON wms_separacao_itens (chave);
 
 -- ─── wms_entregas ──────────────────────────────────────────────────────────
 
--- Verificação rápida de AguardandoNF (evita varredura total)
-CREATE INDEX IF NOT EXISTS idx_entregas_status
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_entregas_status
   ON wms_entregas (status);
 
--- Filtro de 3 dias para Entregue
-CREATE INDEX IF NOT EXISTS idx_entregas_status_data_entregue
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_entregas_status_data_entregue
   ON wms_entregas (status, data_entregue);

--- a/backend/scripts/matar_conexoes_presas.sql
+++ b/backend/scripts/matar_conexoes_presas.sql
@@ -1,0 +1,19 @@
+-- Mata conexões presas/travadas no banco do WMS.
+-- Executar ANTES de criar os índices caso algum index tenha ficado bloqueado.
+
+-- 1. Ver conexões ativas há mais de 5 minutos
+SELECT pid, now() - query_start AS duracao, state, query
+FROM pg_stat_activity
+WHERE state IN ('active', 'idle in transaction')
+  AND query_start < NOW() - INTERVAL '5 minutes'
+  AND query NOT ILIKE '%pg_stat_activity%'
+ORDER BY duracao DESC;
+
+-- 2. Matar as conexões travadas (substitua pelos PIDs do resultado acima
+--    OU use o bloco abaixo para matar todas as longas de uma vez)
+SELECT pg_terminate_backend(pid)
+FROM pg_stat_activity
+WHERE state IN ('active', 'idle in transaction')
+  AND query_start < NOW() - INTERVAL '5 minutes'
+  AND query NOT ILIKE '%pg_stat_activity%'
+  AND pid <> pg_backend_pid();

--- a/backend/src/routes/painelEntrega.ts
+++ b/backend/src/routes/painelEntrega.ts
@@ -4,7 +4,6 @@ import { logger } from "../utils/logger"
 
 const router = express.Router()
 
-// Transições de status permitidas por ação do usuário
 const TRANSICOES_VALIDAS: Record<string, string> = {
   SaiuEntrega: "NFEmitida",
   Entregue: "SaiuEntrega",
@@ -15,26 +14,9 @@ const CAMPO_DATA: Record<string, string> = {
   Entregue: "data_entregue",
 }
 
+// Leitura pura — sem tocar na view legada, sem locks
 router.get("/", async (_req, res) => {
   try {
-    // Só consulta a view pesada quando há registros em AguardandoNF
-    const temPendentes = await productPool.query(
-      `SELECT 1 FROM wms_entregas WHERE status = 'AguardandoNF' LIMIT 1`,
-    )
-
-    if (temPendentes.rows.length > 0) {
-      await productPool.query(
-        `UPDATE wms_entregas
-         SET status = 'NFEmitida', data_nf = NOW()
-         WHERE status = 'AguardandoNF'
-           AND NOT EXISTS (
-             SELECT 1
-             FROM vs_wms_fpainel_saida ps
-             WHERE ps.chave::text = wms_entregas.chave::text
-           )`,
-      )
-    }
-
     const result = await productPool.query(
       `SELECT
          id, chave, codloja, np, destinario, endereco, cidade_uf,
@@ -50,6 +32,36 @@ router.get("/", async (_req, res) => {
   } catch (error) {
     logger.error("Erro ao buscar painel de entregas:", error)
     res.status(500).json({ erro: "Erro ao buscar entregas" })
+  }
+})
+
+// Detecção de NF emitida — chamado pelo frontend em background,
+// separado do polling de leitura para não bloquear a UI
+router.post("/sincronizar-nf", async (_req, res) => {
+  try {
+    const temPendentes = await productPool.query(
+      `SELECT 1 FROM wms_entregas WHERE status = 'AguardandoNF' LIMIT 1`,
+    )
+
+    if (temPendentes.rows.length === 0) {
+      return res.json({ atualizados: 0 })
+    }
+
+    const result = await productPool.query(
+      `UPDATE wms_entregas
+       SET status = 'NFEmitida', data_nf = NOW()
+       WHERE status = 'AguardandoNF'
+         AND NOT EXISTS (
+           SELECT 1
+           FROM vs_wms_fpainel_saida ps
+           WHERE ps.chave::text = wms_entregas.chave::text
+         )`,
+    )
+
+    res.json({ atualizados: result.rowCount ?? 0 })
+  } catch (error) {
+    logger.error("Erro ao sincronizar NF emitida:", error)
+    res.status(500).json({ erro: "Erro ao sincronizar NF" })
   }
 })
 

--- a/frontend/src/pages/PainelEntrega.tsx
+++ b/frontend/src/pages/PainelEntrega.tsx
@@ -90,11 +90,27 @@ const PainelEntrega: React.FC = () => {
     }
   }, [])
 
-  useEffect(() => {
-    buscarEntregas()
-    const interval = setInterval(buscarEntregas, 30000)
-    return () => clearInterval(interval)
+  // Roda em background sem bloquear o carregamento dos dados
+  const sincronizarNF = useCallback(async () => {
+    try {
+      await api.post("/painel-entrega/sincronizar-nf")
+      await buscarEntregas()
+    } catch {
+      // falha silenciosa — dado continua visível normalmente
+    }
   }, [buscarEntregas])
+
+  useEffect(() => {
+    void buscarEntregas()
+    // NF sync em background ao abrir e a cada 5 minutos
+    void sincronizarNF()
+    const intervalDados = setInterval(() => void buscarEntregas(), 30000)
+    const intervalNF = setInterval(() => void sincronizarNF(), 300000)
+    return () => {
+      clearInterval(intervalDados)
+      clearInterval(intervalNF)
+    }
+  }, [buscarEntregas, sincronizarNF])
 
   const entregasFiltradas = useMemo(() => {
     return entregas.filter((item) => {


### PR DESCRIPTION
## Causa raiz
O `UPDATE ... NOT EXISTS (vs_wms_fpainel_saida)` rodava **dentro** do `GET /painel-entrega`. Quando a view demorava (7 JOINs no legado), o request ficava pendurado, a conexão do pool ficava ocupada, e cada novo poll de 30s empilhava mais uma conexão presa. Essas conexões presas bloqueavam a tabela `wms_entregas`, impedindo até o `CREATE INDEX`.

## Solução

Separação completa entre leitura e sincronização:

```
GET  /painel-entrega        → SELECT puro, instantâneo
POST /painel-entrega/sincronizar-nf  → UPDATE contra view legada, em background
```

O frontend chama o GET a cada 30s (polling rápido) e o POST a cada 5 minutos em background — sem nunca bloquear o carregamento dos dados.

## Índices
Script atualizado para `CREATE INDEX CONCURRENTLY` (sem lock de tabela durante criação).

Novo script `matar_conexoes_presas.sql` para limpar sessões travadas antes de criar os índices.

## Ordem de execução no banco
1. Rodar `matar_conexoes_presas.sql` para matar conexões penduradas
2. Rodar `criar_indices_performance.sql` (agora com CONCURRENTLY — não bloqueia)

Generated with Claude Code